### PR TITLE
upd: Update doc (Shortcuts, link to specifications)

### DIFF
--- a/doc/5.5/certificateExtensions.html
+++ b/doc/5.5/certificateExtensions.html
@@ -15,7 +15,7 @@ be attached to the certificate.
 <p>
   KeyStore Explorer supports the addition of most of the set of extensions
   specified in RFC 5280 (Certificate Profile) and the Netscape Certificate
-  Extensions. See <a href="/specifications.html">Specifications</a> for details
+  Extensions. See <a href="specifications.html">Specifications</a> for details
   of supported certificate extensions.
 </p>
 <p>

--- a/doc/5.5/keyboardShortcuts.html
+++ b/doc/5.5/keyboardShortcuts.html
@@ -146,10 +146,16 @@ There are keyboard shortcuts available to activate common operations:
       <td>Display the properties of the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-F</td>
-      <td nowrap>Cmd-F</td>
+      <td nowrap>Ctrl-E</td>
+      <td nowrap>Cmd-E</td>
       <td>Examine File</td>
       <td>Examine the contents of a file</td>
+    </tr>
+    <tr>
+      <td nowrap>Ctrl-F</td>
+      <td nowrap>Cmd-F</td>
+      <td>Find</td>
+      <td>Find an Entry name</td>
     </tr>
     <tr>
       <td nowrap>Ctrl-L</td>

--- a/features.html
+++ b/features.html
@@ -14,7 +14,7 @@ title: KeyStore Explorer - Features
 </p>
 
 <p>
-    <a href="specifications.html">Full specifications</a> are available for KeyStore Explorer,
+    <a href="/doc/5.5/specifications.html">Full specifications</a> are available for KeyStore Explorer,
     including supported algorithms, key sizes and file formats.
 </p>
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@ title: KeyStore Explorer
         <p>
             KeyStore Explorer can be used to create your own CA certificate and
             sign certificates and CRLs with it. A wide range of certificate extensions
-            is supported, see <a href="specifications.html">specifications</a>.
+            is supported, see <a href="/doc/5.5/specifications.html">specifications</a>.
         </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
upd: fix 5.5 Shortcuts
- Examine File: `Ctrl-E`
- Find: `Ctrl-F`

Fix some path to `specifications` due to:
- https://github.com/kaikramer/kaikramer.github.io/commit/37441defb224c1f1b44f54ddd1ae8f82e17c7ba1#diff-3dd5ccfab006f23516e70766e9ede56410792b402aab5015d54e6569a9636ee2
_[with some actual 404 errors]_

_[FYI @kaikramer]_