### PR TITLE
doc: Change shortcut's `acceleratorDelimiter` (from `-` to `+`) to be conform with the current GUI (v5.6.0)

### DIFF
--- a/doc/5.6/keyboardShortcuts.html
+++ b/doc/5.6/keyboardShortcuts.html
@@ -24,148 +24,148 @@ There are keyboard shortcuts available to activate common operations:
       <th>macOS</th>
     </tr>
     <tr>
-      <td nowrap>Ctrl-N</td>
-      <td nowrap>Cmd-N</td>
+      <td nowrap>Ctrl+N</td>
+      <td nowrap>Cmd+N</td>
       <td>New</td>
       <td>Create a new KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-O</td>
-      <td nowrap>Cmd-O</td>
+      <td nowrap>Ctrl+O</td>
+      <td nowrap>Cmd+O</td>
       <td>Open</td>
       <td>Open an existing KeyStore from disk</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-D</td>
-      <td nowrap>Cmd+Shift-D</td>
+      <td nowrap>Ctrl+Shift+D</td>
+      <td nowrap>Cmd+Shift+D</td>
       <td>Open</td>
       <td>Open the Default KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-C</td>
-      <td nowrap>Cmd+Shift-C</td>
+      <td nowrap>Ctrl+Shift+C</td>
+      <td nowrap>Cmd+Shift+C</td>
       <td>Open</td>
       <td>Open the CA Certificates KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-1</td>
-      <td nowrap>Cmd+Shift-1</td>
+      <td nowrap>Ctrl+Shift+1</td>
+      <td nowrap>Cmd+Shift+1</td>
       <td>Open PKCS#11</td>
       <td>Open an PKCS#11 KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-M</td>
-      <td nowrap>Cmd+Shift-M</td>
+      <td nowrap>Ctrl+Shift+M</td>
+      <td nowrap>Cmd+Shift+M</td>
       <td>Open Windows-MY</td>
       <td>Open Windows-MY KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-W</td>
-      <td nowrap>Cmd-W</td>
+      <td nowrap>Ctrl+W</td>
+      <td nowrap>Cmd+W</td>
       <td>Close</td>
       <td>Close the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-W</td>
-      <td nowrap>Cmd+Shift-W</td>
+      <td nowrap>Ctrl+Shift+W</td>
+      <td nowrap>Cmd+Shift+W</td>
       <td>Close All</td>
       <td>Close all KeyStores</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-S</td>
-      <td nowrap>Cmd-S</td>
+      <td nowrap>Ctrl+S</td>
+      <td nowrap>Cmd+S</td>
       <td>Save</td>
       <td>Save the active KeyStore to disk</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-S</td>
-      <td nowrap>Cmd+Alt-S</td>
+      <td nowrap>Ctrl+Alt+S</td>
+      <td nowrap>Cmd+Alt+S</td>
       <td>Save As</td>
       <td>Save the active KeyStore to disk with a new name</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Shift-S</td>
-      <td nowrap>Cmd+Shift-S</td>
+      <td nowrap>Ctrl+Shift+S</td>
+      <td nowrap>Cmd+Shift+S</td>
       <td>Save All</td>
       <td>Save all changed KeyStores</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-Z</td>
-      <td nowrap>Cmd-Z</td>
+      <td nowrap>Ctrl+Z</td>
+      <td nowrap>Cmd+Z</td>
       <td>Undo</td>
       <td>Undo the last action</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-Y</td>
-      <td nowrap>Cmd-Y</td>
+      <td nowrap>Ctrl+Y</td>
+      <td nowrap>Cmd+Y</td>
       <td>Redo</td>
       <td>Redo the previously undone action</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-X</td>
-      <td nowrap>Cmd-X</td>
+      <td nowrap>Ctrl+X</td>
+      <td nowrap>Cmd+X</td>
       <td>Cut</td>
       <td>Cut the selected KeyStore entry to the buffer</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-C</td>
-      <td nowrap>Cmd-C</td>
+      <td nowrap>Ctrl+C</td>
+      <td nowrap>Cmd+C</td>
       <td>Copy</td>
       <td>Copy the selected KeyStore entry to the buffer</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-V</td>
-      <td nowrap>Cmd-V</td>
+      <td nowrap>Ctrl+V</td>
+      <td nowrap>Cmd+V</td>
       <td>Paste</td>
       <td>Paste the buffer's contents into the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-C</td>
-      <td nowrap>Cmd+Alt-C</td>
+      <td nowrap>Ctrl+Alt+C</td>
+      <td nowrap>Cmd+Alt+C</td>
       <td>Compare</td>
       <td>Compare certificates</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-G</td>
-      <td nowrap>Cmd-G</td>
+      <td nowrap>Ctrl+G</td>
+      <td nowrap>Cmd+G</td>
       <td>Generate Key Pair</td>
       <td>
         Generate a Key Pair with self-signed certificate in the active KeyStore
       </td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-G</td>
-      <td nowrap>Cmd+Alt-G</td>
+      <td nowrap>Ctrl+Alt+G</td>
+      <td nowrap>Cmd+Alt+G</td>
       <td>Generate Secret Key</td>
       <td>Generate a Secret Key in the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-D</td>
-      <td nowrap>Cmd+Alt-D</td>
+      <td nowrap>Ctrl+Alt+D</td>
+      <td nowrap>Cmd+Alt+D</td>
       <td>Generate DH Parameters</td>
       <td>Generate Diffie–Hellman Parameters</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-T</td>
-      <td nowrap>Cmd-T</td>
+      <td nowrap>Ctrl+T</td>
+      <td nowrap>Cmd+T</td>
       <td>Import Trusted Certificate</td>
       <td>Import a Trusted Certificate into the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-K</td>
-      <td nowrap>Cmd-K</td>
+      <td nowrap>Ctrl+K</td>
+      <td nowrap>Cmd+K</td>
       <td>Import Key Pair</td>
       <td>Import a Key Pair into the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-V</td>
-      <td nowrap>Cmd+Alt-V</td>
+      <td nowrap>Ctrl+Alt+V</td>
+      <td nowrap>Cmd+Alt+V</td>
       <td>Verify PKCS#7/CMS signature</td>
       <td>Verify a PKCS#7/CMS signature</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-P</td>
-      <td nowrap>Cmd-P</td>
+      <td nowrap>Ctrl+P</td>
+      <td nowrap>Cmd+P</td>
       <td>Set Password</td>
       <td>Set the active KeyStore's password</td>
     </tr>
@@ -176,38 +176,38 @@ There are keyboard shortcuts available to activate common operations:
       <td>Display the details of the currently selected KeyStore entry</td>
     </tr>
     <tr>
-      <td nowrap>Alt-Enter</td>
-      <td nowrap>Alt-Enter</td>
+      <td nowrap>Alt+Enter</td>
+      <td nowrap>Alt+Enter</td>
       <td>Properties</td>
       <td>Display the properties of the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-E</td>
-      <td nowrap>Cmd-E</td>
+      <td nowrap>Ctrl+E</td>
+      <td nowrap>Cmd+E</td>
       <td>Examine File</td>
       <td>Examine the contents of a file</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-F</td>
-      <td nowrap>Cmd-F</td>
+      <td nowrap>Ctrl+F</td>
+      <td nowrap>Cmd+F</td>
       <td>Find</td>
       <td>Find an entry in the active KeyStore</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-L</td>
-      <td nowrap>Cmd-L</td>
+      <td nowrap>Ctrl+L</td>
+      <td nowrap>Cmd+L</td>
       <td>Examine Clipboard</td>
       <td>Examine the contents of the system clipboard</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl+Alt-S</td>
-      <td nowrap>Cmd+Alt-S</td>
+      <td nowrap>Ctrl+Alt+S</td>
+      <td nowrap>Cmd+Alt+S</td>
       <td>Examine SSL</td>
       <td>Examine a Secure Sockets Layer (SSL) connection's certificate(s)</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-D</td>
-      <td nowrap>Cmd-D</td>
+      <td nowrap>Ctrl+D</td>
+      <td nowrap>Cmd+D</td>
       <td>Detect File Type</td>
       <td>Detect a cryptographic file's type</td>
     </tr>
@@ -224,8 +224,8 @@ There are keyboard shortcuts available to activate common operations:
       <td>Rename the Key entry</td>
     </tr>
     <tr>
-      <td nowrap>Ctrl-,</td>
-      <td nowrap>Cmd-,</td>
+      <td nowrap>Ctrl+,</td>
+      <td nowrap>Cmd+,</td>
       <td>Preferences</td>
       <td>Display KeyStore Explorer's preferences dialog</td>
     </tr>
@@ -236,14 +236,14 @@ There are keyboard shortcuts available to activate common operations:
       <td>Close currently opened dialog</td>
     </tr>
     <tr>
-      <td nowrap>Alt-F4</td>
+      <td nowrap>Alt+F4</td>
       <td nowrap>N/A</td>
       <td>Exit</td>
       <td>Exit KeyStore Explorer</td>
     </tr>
     <tr>
       <td nowrap>N/A</td>
-      <td nowrap>Cmd-Q</td>
+      <td nowrap>Cmd+Q</td>
       <td>Quit</td>
       <td>Quit KeyStore Explorer</td>
     </tr>


### PR DESCRIPTION

_Helped by_ :copilot: 

Thanks to :copilot: to discover duplicate shortcut `Ctrl+Alt+S`:
- `Save As`
- `Examine SSL`

Close #8