### PR TITLE
replace `SSL` with `TLS/SSL` (especially on `doc/5.6`)

### DIFF
--- a/doc/5.6/examineFiles.html
+++ b/doc/5.6/examineFiles.html
@@ -64,24 +64,24 @@ CRL):
   </li>
 </ol>
 
-<h1>Examine an SSL Connection</h1>
+<h1>Examine an TLS/SSL Connection</h1>
 <hr />
 
-To examine an SSL connection's certificates:
+To examine a Transport Layer Security (TLS) connection's certificates:
 
 <ol>
   <li>
-    From the <b>Examine</b> menu, choose <b>Examine SSL</b>. Alternatively click
-    on the <b>Examine SSL</b> tool bar button:
+    From the <b>Examine</b> menu, choose <b>Examine TLS/SSL</b>. Alternatively click
+    on the <b>Examine TLS/SSL</b> tool bar button:
     &nbsp;&nbsp;&nbsp;&nbsp;<img src="images/examinessl.png" />
   </li>
 
 
-  <li>The <b>Examine SSL</b> dialog will appear.</li>
+  <li>The <b>Examine TLS/SSL</b> dialog will appear.</li>
 
 
   <li>
-    Enter the <b>SSL Host</b> and <b>Port</b> of the connection to be examined.
+    Enter the <b>TLS Host</b> and <b>Port</b> of the connection to be examined.
     Your last ten input values are saved and available via the drop down box.
   </li>
 
@@ -89,7 +89,7 @@ To examine an SSL connection's certificates:
   <li>
     Optionally you can activate <b>client authentication</b>. You have just to
     select a KeyStore and the private key from KeyStore is used to authenticate
-    against the SSL server. If there is more than one private key in the
+    against the TLS/SSL server. If there is more than one private key in the
     KeyStore that could be used for client authentication, then standard Java
     mechanisms are used to find the right one.
   </li>
@@ -98,7 +98,7 @@ To examine an SSL connection's certificates:
   <li>Click on the <b>OK</b> button.</li>
 
 
-  <li>The <b>Certificate Details for SSL Connection</b> dialog will appear.</li>
+  <li>The <b>Certificate Details for TLS/SSL Connection</b> dialog will appear.</li>
 
 
   <li>

--- a/doc/5.6/keyPairs.html
+++ b/doc/5.6/keyPairs.html
@@ -215,7 +215,7 @@ To generate a CSR for a Key Pair:
         For PKCS#10 format you can optionally enter a <b>company name</b> (which
         becomes an "unstructuredName" attribute in the request) and/or add the
         <b>extensions</b> from the certificate to the request. The latter is useful
-        for SSL certificates with SubjectAlternativeName extensions.
+        for TLS/SSL certificates with SubjectAlternativeName extensions.
     </li>
 
 

--- a/doc/5.6/keyboardShortcuts.html
+++ b/doc/5.6/keyboardShortcuts.html
@@ -202,8 +202,8 @@ There are keyboard shortcuts available to activate common operations:
     <tr>
       <td nowrap>Ctrl+Alt-S</td>
       <td nowrap>Cmd+Alt-S</td>
-      <td>Examine SSL</td>
-      <td>Examine a Secure Sockets Layer (SSL) connection's certificate(s)</td>
+      <td>Examine TLS/SSL</td>
+      <td>Examine a Transport Layer Security (TLS) connection's certificate(s)</td>
     </tr>
     <tr>
       <td nowrap>Ctrl-D</td>

--- a/doc/5.6/overview.html
+++ b/doc/5.6/overview.html
@@ -53,7 +53,7 @@ certificates, to generate Key Pairs and change KeyStore type.
 
 <p>
 
-The contents of Certificate and CRL files and SSL connections
+The contents of Certificate and CRL files and TLS/SSL connections
 can be examined through items in the <b>Examine</b> menu.
 </p>
 

--- a/doc/5.6/preferences.html
+++ b/doc/5.6/preferences.html
@@ -188,7 +188,7 @@ KeyStore Explorer can be configured to use a variety of user interface look and 
 <hr />
 
 Your network may require the use of a proxy to access the Internet. KeyStore
-Explorer utilizes the Internet to check for updates and examine SSL connections.
+Explorer utilizes the Internet to check for updates and examine TLS/SSL connections.
 Configuration is required to use such features with a proxy.
 
 <p>

--- a/doc/5.6/toolBar.html
+++ b/doc/5.6/toolBar.html
@@ -137,8 +137,8 @@ The application tool bar contains several buttons to activate common operations:
       <td>
         <center><img src="images/examinessl.png" /></center>
       </td>
-      <td>Examine SSL</td>
-      <td>Examine a Secure Sockets Layer (SSL) connection's certificate(s)</td>
+      <td>Examine TLS/SSL</td>
+      <td>Examine a Transport Layer Security (TLS) connection's certificate(s)</td>
     </tr>
     <tr>
       <td>

--- a/features.html
+++ b/features.html
@@ -69,7 +69,7 @@ title: KeyStore Explorer - Features
 
         <ul class="level1">
             <li>Import X.509 certificate files as trusted certificates.</li>
-            <li>View the details of certificates contained within KeyStore entries, certificate files and SSL web sites.</li>
+            <li>View the details of certificates contained within KeyStore entries, certificate files and TLS/SSL web sites.</li>
             <li>Export certificates in a variety of formats (X.509, PKCS #7, PKI Path, SPC).</li>
             <li>Export certificate public keys in OpenSSL (SubjectPublicKeyInfo) format.</li>
             <li>View the details of Certificate Revocation List (CRL) files.</li>

--- a/release54.html
+++ b/release54.html
@@ -270,7 +270,7 @@ title: KeyStore Explorer - Release Notes
                 </td>
             </tr>
             <tr class="plain_even">
-                <td>SSL Server</td>
+                <td>TLS/SSL Server</td>
                 <td>
                     Authority Key Identifier <br />
                     Subject Key Identifier <br />
@@ -279,7 +279,7 @@ title: KeyStore Explorer - Release Notes
                 </td>
             </tr>
             <tr class="plain_odd">
-                <td>SSL Client</td>
+                <td>TLS/SSL Client</td>
                 <td>
                     Authority Key Identifier <br />
                     Subject Key Identifier <br />
@@ -304,7 +304,7 @@ title: KeyStore Explorer - Release Notes
         <p>
             Note that these template sets are not necessarily complete, they are rather a starting point (which might be
             sufficient for some purposes).
-            For example a SSL server certificate should also contain a Subject Alternative Name (SAN) extension with the site
+            For example a TLS/SSL server certificate should also contain a Subject Alternative Name (SAN) extension with the site
             name in it.
         </p>
     </div>
@@ -326,8 +326,8 @@ title: KeyStore Explorer - Release Notes
             file system:
             <ul>
                 <li>Examine File (Ctrl-F)</li>
-                <li>Examine Clipboard (Ctrl-F)</li>
-                <li>Examine SSL (Ctrl-Alt-S)</li>
+                <li>Examine Clipboard (Ctrl-L)</li>
+                <li>Examine TLS/SSL (Ctrl-Alt-S)</li>
             </ul>
         </p>
         <p>

--- a/release55.html
+++ b/release55.html
@@ -677,7 +677,7 @@ title: KeyStore Explorer - Release Notes
                 <li>Added popup menu for multiple entry selection</li>
                 <li>Added handler for viewing files via system clipboard (copy file, then do "Examine System Clipboard")</li>
                 <li>Added jar/apk files to "Examine File" feature, which shows the signature certificates for signed jars (dragging and dropping a jar file onto KSE works as well)</li>
-                <li>Added SAN extension to SSL server template</li>
+                <li>Added SAN extension to TLS/SSL server template</li>
                 <li>Subject DNs can be empty now (explicitly allowed in RFC 5280)</li>
                 <li>Removed old Netscape extensions from AddExtensions dialog</li>
                 <li>Added OIDs of three private Apple certificate extensions to extension viewer</li>


### PR DESCRIPTION
Hello KSC Team, @kaikramer,

Similar to:
- kaikramer/keystore-explorer#512
_(Thanks @stokito)_

Here is a PR, in the documentation, in order to:
- replace `SSL` with `TLS/SSL` (especially on `doc/5.6`)
- fix minor typo on `Examine Clipboard (Ctrl-L)` on v5.4

Regards,
Th.